### PR TITLE
Fixed: Unable to discover M2 Reader

### DIFF
--- a/lib/models/reader.dart
+++ b/lib/models/reader.dart
@@ -26,7 +26,7 @@ class StripeReader {
       locationStatus: LocationStatus.values[json["locationStatus"]],
       batteryStatus: BatteryStatus.values[json["batteryStatus"]],
       deviceType: DeviceType.values[json["deviceType"]],
-      originalJSON: Map.from(json["originalJSON"]),
+      originalJSON: Map.from(json["originalJSON"] ?? {}),
       simulated: json["simulated"],
       label: json["label"],
       availableUpdate: json["availableUpdate"],


### PR DESCRIPTION
Was also encountering some issue when discovering M2 Card Readers.

Going through the code, native code was actually able to discover the M2 Card Reader. 
It seems that it was failing when parsing the json to `StripeReader` object.
When discovering an M2 Card reader, it was not having any `originalJSON` field which was causing it to fail.

e.g
Sample json object received when an M2 reader is discovered (I've only changed the serial number):
`{locationStatus: 2, deviceType: 3, originalJSON: null, serialNumber: <SERIAL_NO>, batteryStatus: 0, locationId: null, simulated: false, availableUpdate: false, label: null}]`

Added some null check into the field for it to not cause error.